### PR TITLE
fix: support symbolic FP with string solver (z3str3)

### DIFF
--- a/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/generic/NumericConstraintTranslator.java
+++ b/jpf-symbc/src/main/edu/ucsb/cs/vlab/translate/smtlib/generic/NumericConstraintTranslator.java
@@ -42,7 +42,11 @@ public abstract class NumericConstraintTranslator extends NormalFormTranslator<C
 	public List<String> transformChain(Constraint instance, List<String> collection) {
 		if (instance == null)
 			return collection;
-		if (!GreenConstraint.class.isInstance(instance))
+		if (instance instanceof RealConstraint){
+			// throw new UnsupportedOperationException(" Constraints are being dropped");
+			return transformChain(instance.getTail(), collection);
+		} else
+			if (!GreenConstraint.class.isInstance(instance))
 			collection.add(transform(instance));
 		else {
 			// TODO translate GreenConstraint to a solver string
@@ -153,7 +157,7 @@ public abstract class NumericConstraintTranslator extends NormalFormTranslator<C
 			l = c.getLeft();
 			r = c.getRight();
 
-			String a = manager.numExpr.collect((IntegerExpression) l);
+			String a = manager.numExpr.collect((IntegerExpression) l); // throws classcastexception for realexpressions
 			String b = manager.numExpr.collect((IntegerExpression) r);
 			Comparator cmp = c.getComparator();
 

--- a/jpf-symbc/src/tests/gov/nasa/jpf/symbc/fp/ConstraintMixBug.java
+++ b/jpf-symbc/src/tests/gov/nasa/jpf/symbc/fp/ConstraintMixBug.java
@@ -1,6 +1,10 @@
 package gov.nasa.jpf.symbc.fp;
 
 public class ConstraintMixBug {
+    public static void main(String[] args){
+        ConstraintMixBug test = new ConstraintMixBug();
+        test.testNaN(5.0f);
+    }
     public void testNaN(float x) {
         assert x != x;
     }

--- a/jpf-symbc/src/tests/gov/nasa/jpf/symbc/fp/ConstraintMixBug.java
+++ b/jpf-symbc/src/tests/gov/nasa/jpf/symbc/fp/ConstraintMixBug.java
@@ -1,0 +1,7 @@
+package gov.nasa.jpf.symbc.fp;
+
+public class ConstraintMixBug {
+    public void testNaN(float x) {
+        assert x != x;
+    }
+}

--- a/jpf-symbc/src/tests/gov/nasa/jpf/symbc/fp/configConstraintMixBug.jpf
+++ b/jpf-symbc/src/tests/gov/nasa/jpf/symbc/fp/configConstraintMixBug.jpf
@@ -1,0 +1,32 @@
+classpath = /home/salmane/IdeaProjects/java-ranger/jpf-symbc/build/tests
+target = gov.nasa.jpf.symbc.fp.ConstraintMixBug
+symbolic.method=gov.nasa.jpf.symbc.fp.ConstraintMixBug.testNaN(sym)
+jvm.insn_factory.class=gov.nasa.jpf.symbc.SymbolicInstructionFactory
+symbolic.dp=z3bitvector
+symbolic.min_int=-2147483648
+symbolic.max_int=2147483647
+symbolic.min_double=-10000.0
+symbolic.max_double=10000.0
+symbolic.bvlength=64
+search.depth_limit=13
+symbolic.strings=true
+symbolic.string_dp=z3str3
+symbolic.string_dp_timeout_ms=3000
+symbolic.lazy=on
+symbolic.jrarrays=true
+veritestingMode=4
+recursiveDepth=200
+singlePathOptimization=true
+
+symbolic.fp=true
+listener=gov.nasa.jpf.symbc.VeritestingListener
+symbolic.debug=true
+
+symbolic.optimizechoices=false
+
+symbolic.debug=true
+search.multiple_errors=true
+vm.path_output=true
+vm.store_steps=true
+report.console.show_steps=true
+report.console.transition=constraint,snapshot


### PR DESCRIPTION
## Post-Mortem: ClassCastException with symbolic.fp + string solver
Incident: Crash (ClassCastException) when symbolic.fp=true is combined with the string solver (symbolic.string_dp=z3str3). A secondary NumberFormatException surfaced immediately once the first crash was fixed.

### Root cause
The string solver aliases the entire numeric PathCondition (StringPathCondition calls Translator.translate calls manager.numCons.collect(npc)), not just string-relevant constraints. IntermediateConstraint.transform unconditionally casts both operands to (IntegerExpression):
```java
String a = manager.numExpr.collect((IntegerExpression) l);
```

Moving a floating-point program under the string tree put SymbolicReal/RealConstant operands in front of that cast resulting in ClassCastException. The crash axis is the operand type (RealExpression), not the constraint class. Reals are always decided by the numeric solver (z3/z3bitvector) and are unrepresentable in the string SMT backend (z3str3), so a real operand is never relevant to string translation.

Timeline of attempts
1. PR hack (e215c62) — instanceof RealConstraint skip in transformChain. Wrong axis: guards by constraint class. MixedConstraint with real operands still crashes. Also mislabeled a numeric-origin line and disabled rescheduling for the target.
2. Minimal fix (f05d4bb) — drop any node whose operand is a RealExpression:
```java
if (instance.getLeft() instanceof RealExpression
        || instance.getRight() instanceof RealExpression)
    return transformChain(instance.getTail(), collection);
```
5 lines, no new imports; subsumes the hack (every RealConstraint has real operands), catches MixedConstraint and any other carrier. GreenConstraint has null operands (super(null,null,null)) and is unaffected.

Secondary fix (6dd3f46) in ProblemZ3BitVector.getFPValue: Z3 prints negative FP model values as (- 2052); Double.parseDouble rejects "(-" resulting in a NumberFormatException. So i added the (- N) for -Double.parseDouble(inner) branch.
### Verification
- 4 SV-COMP benchmarks: float, double2long, GraphFragment_false, ExSymExeFNEG_false. now reach their expected violations at comparable cost.
