### PR TITLE
implement missing Z3 operations in ProblemZ3 and ProblemZ3BitVector

### DIFF
--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3.java
@@ -1058,19 +1058,32 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public Object mixed(Object exp1, Object exp2) {
-		// TODO Auto-generated method stub
-		throw new RuntimeException("## Error Z3 \n");
+		try {
+			if (useFpForReals) {
+				IntExpr intExpr = (IntExpr) (exp1 instanceof IntExpr ? exp1 : exp2);
+				FPExpr fpExpr = (FPExpr) (exp1 instanceof FPExpr ? exp1 : exp2);
+				RealExpr realExpr = ctx.mkInt2Real(intExpr);
+				FPExpr converted = ctx.mkFPToFP(ctx.mkFPRoundTowardZero(), realExpr, ctx.mkFPSort64());
+				return ctx.mkFPEq(fpExpr, converted);
+			} else {
+				IntExpr intExpr = (IntExpr) (exp1 instanceof IntExpr ? exp1 : exp2);
+				RealExpr realExpr = (RealExpr) (exp1 instanceof RealExpr ? exp1 : exp2);
+				return ctx.mkEq(ctx.mkInt2Real(intExpr), realExpr);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException("## Error Z3: mixed(Object, Object) failed.\n" + e);
+		}
 	}
 
     @Override
     public double getRealValueInf(Object dpVar) {
-        throw new RuntimeException("## Error Z3 \n");//return 0;
+        return getRealValue(dpVar);
     }
 
 	@Override
 	public double getRealValueSup(Object dpVar) {
-		// TODO Auto-generated method stub
-	    throw new RuntimeException("## Error Z3 \n");//return 0;
+		return getRealValue(dpVar);
 	}
 
 	@Override
@@ -1091,8 +1104,16 @@ public class ProblemZ3 extends ProblemGeneral {
 
 	@Override
 	public void postLogicalOR(Object[] constraint) {
-		// TODO Auto-generated method stub
-		throw new RuntimeException("## Error Z3 \n");
+		try {
+			BoolExpr[] exprs = new BoolExpr[constraint.length];
+			for (int i = 0; i < constraint.length; i++) {
+				exprs[i] = (BoolExpr) constraint[i];
+			}
+			solver.add(ctx.mkOr(exprs));
+		} catch (Exception e) {
+			e.printStackTrace();
+			throw new RuntimeException("## Error Z3: postLogicalOR() failed.\n" + e);
+		}
 	}
 
     // Added by Aymeric to support arrays

--- a/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3BitVector.java
+++ b/jpf-symbc/src/main/gov/nasa/jpf/symbc/numeric/solvers/ProblemZ3BitVector.java
@@ -782,6 +782,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
                 return ctx.mkBVMul((BitVecExpr) exp1, (BitVecExpr) exp2);
             } else if (exp1 instanceof IntExpr && exp2 instanceof IntExpr) {
                 return ctx.mkMul((IntExpr) exp1, (IntExpr) exp2);
+            } else if (exp1 instanceof RealExpr && exp2 instanceof RealExpr) {
+                return ctx.mkMul((RealExpr) exp1, (RealExpr) exp2);
             } else if (exp1 instanceof FPExpr && exp2 instanceof FPExpr) {
                 return ctx.mkFPMul(ctx.mkFPRoundNearestTiesToEven(), (FPExpr) exp1, (FPExpr) exp2);}
                 else{
@@ -834,6 +836,10 @@ public class ProblemZ3BitVector extends ProblemGeneral {
                 return ctx.mkBVSDiv((BitVecExpr) exp1, (BitVecExpr) exp2);
             } else if (exp1 instanceof IntExpr && exp2 instanceof IntExpr) {
                 return ctx.mkDiv((IntExpr) exp1, (IntExpr) exp2);
+            } else if (exp1 instanceof RealExpr && exp2 instanceof RealExpr) {
+                return ctx.mkDiv((RealExpr) exp1, (RealExpr) exp2);
+            } else if (exp1 instanceof FPExpr && exp2 instanceof FPExpr) {
+                return ctx.mkFPDiv(ctx.mkFPRoundNearestTiesToEven(), (FPExpr) exp1, (FPExpr) exp2);
             } else {
                 throw new RuntimeException();
             }
@@ -848,6 +854,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
         try {
             if (exp instanceof BitVecExpr) {
                 return ctx.mkBVSRem((BitVecExpr) exp, ctx.mkBV(value, this.bitVectorLength));
+            } else if (exp instanceof IntExpr) {
+                return ctx.mkRem((IntExpr) exp, ctx.mkInt(value));
             } else {
                 throw new RuntimeException();
             }
@@ -862,6 +870,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
         try {
             if (exp instanceof BitVecExpr) {
                 return ctx.mkBVSRem(ctx.mkBV(value, this.bitVectorLength), (BitVecExpr) exp);
+            } else if (exp instanceof IntExpr) {
+                return ctx.mkRem(ctx.mkInt(value), (IntExpr) exp);
             } else {
                 throw new RuntimeException();
             }
@@ -875,6 +885,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
         try {
             if (exp1 instanceof BitVecExpr && exp2 instanceof BitVecExpr) {
                 return ctx.mkBVSRem((BitVecExpr) exp1, (BitVecExpr) exp2);
+            } else if (exp1 instanceof IntExpr && exp2 instanceof IntExpr) {
+                return ctx.mkRem((IntExpr) exp1, (IntExpr) exp2);
             } else {
                 throw new RuntimeException();
             }
@@ -889,6 +901,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
         try {
             if (exp instanceof BitVecExpr) {
                 return ctx.mkBVSMod((BitVecExpr) exp, ctx.mkBV(value, this.bitVectorLength));
+            } else if (exp instanceof IntExpr) {
+                return ctx.mkMod((IntExpr) exp, ctx.mkInt(value));
             } else {
                 throw new RuntimeException();
             }
@@ -903,6 +917,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
         try {
             if (exp instanceof BitVecExpr) {
                 return ctx.mkBVSMod(ctx.mkBV(value, this.bitVectorLength), (BitVecExpr) exp);
+            } else if (exp instanceof IntExpr) {
+                return ctx.mkMod(ctx.mkInt(value), (IntExpr) exp);
             } else {
                 throw new RuntimeException();
             }
@@ -916,6 +932,8 @@ public class ProblemZ3BitVector extends ProblemGeneral {
         try {
             if (exp1 instanceof BitVecExpr && exp2 instanceof BitVecExpr) {
                 return ctx.mkBVSMod((BitVecExpr) exp1, (BitVecExpr) exp2);
+            } else if (exp1 instanceof IntExpr && exp2 instanceof IntExpr) {
+                return ctx.mkMod((IntExpr) exp1, (IntExpr) exp2);
             } else {
                 throw new RuntimeException();
             }
@@ -1652,8 +1670,7 @@ public class ProblemZ3BitVector extends ProblemGeneral {
 
     @Override
     public double getRealValueSup(Object dpVar) {
-        // TODO Auto-generated method stub
-        throw new RuntimeException("## Error Z3 \n");// return 0;
+        return getRealValueInf(dpVar);
     }
 
     @Override
@@ -1663,7 +1680,15 @@ public class ProblemZ3BitVector extends ProblemGeneral {
 
     @Override
     public void postLogicalOR(Object[] constraint) {
-        // TODO Auto-generated method stub
-        throw new RuntimeException("## Error Z3 \n");
+        try {
+            BoolExpr[] exprs = new BoolExpr[constraint.length];
+            for (int i = 0; i < constraint.length; i++) {
+                exprs[i] = (BoolExpr) constraint[i];
+            }
+            solver.add(ctx.mkOr(exprs));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("## Error Z3: postLogicalOR() failed.\n" + e);
+        }
     }
 }


### PR DESCRIPTION
- mult/div: add RealExpr branches, div also handles FPExpr via mkFPDiv
- rem/mod: add IntExpr branches using mkRem/mkMod
- mixed: implement int-to-real and int-to-fp conversion in ProblemZ3
- getRealValueInf/Sup: delegate to getRealValue
- postLogicalOR: post constraint disjunction to the solver